### PR TITLE
Change travis email so the Inferno team stops getting our Travis run notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
 notifications:
   email:
     recipients:
-      - inferno@groups.mitre.org
+      - tacoma-fhir-prototyping@groups.mitre.org
     on_failure: change


### PR DESCRIPTION
Turns out when we forked the repo, we forgot to change the Travis notification email away from the Inferno team list, so they're getting all our Travis results. This fixes that.