### PR TITLE
Generic ValueSet Availability Sequence

### DIFF
--- a/lib/app/modules/quality_reporting/valueset_sequence.rb
+++ b/lib/app/modules/quality_reporting/valueset_sequence.rb
@@ -20,12 +20,7 @@ module Inferno
           desc 'Expand each Value Set in a measure to ensure they are available'
         end
 
-        #root = "#{__dir__}/../../../.."
-        #path = File.expand_path('resources/quality_reporting/CMS130/Bundle/cms130-bundle.json', root)
-        #bundle = FHIR::STU3::Bundle.new JSON.parse(File.read(path))
-        #measure_id = 'MitreTestScript-measure-col'
         measure_id = @instance.measure_to_test
-        #measure = get_resource_by_id(bundle, measure_id)
         valueset_urls = get_all_dependent_valuesets(measure_id)
         missing_valuesets = []
 

--- a/lib/app/modules/quality_reporting/valueset_sequence.rb
+++ b/lib/app/modules/quality_reporting/valueset_sequence.rb
@@ -7,11 +7,10 @@ module Inferno
   module Sequence
     class ValueSetSequence < SequenceBase
       include MeasureOperations
-      include BundleParserUtil
       title 'ValueSet Availability'
 
       test_id_prefix 'valueset'
-
+      requires :measure_to_test
       description 'Ensure that all required value sets for a target measure are available'
 
       test 'Check ValueSet Availability' do
@@ -21,13 +20,13 @@ module Inferno
           desc 'Expand each Value Set in a measure to ensure they are available'
         end
 
-        root = "#{__dir__}/../../../.."
-        path = File.expand_path('resources/quality_reporting/CMS130/Bundle/cms130-bundle.json', root)
-        bundle = FHIR::STU3::Bundle.new JSON.parse(File.read(path))
-        measure_id = 'MitreTestScript-measure-col'
-        measure = get_resource_by_id(bundle, measure_id)
-        valueset_urls = get_all_dependent_valuesets(measure, bundle)
-
+        #root = "#{__dir__}/../../../.."
+        #path = File.expand_path('resources/quality_reporting/CMS130/Bundle/cms130-bundle.json', root)
+        #bundle = FHIR::STU3::Bundle.new JSON.parse(File.read(path))
+        #measure_id = 'MitreTestScript-measure-col'
+        measure_id = @instance.measure_to_test
+        #measure = get_resource_by_id(bundle, measure_id)
+        valueset_urls = get_all_dependent_valuesets(measure_id)
         missing_valuesets = []
 
         # NOTE if number of inspected valuesets << server total valuesets, this

--- a/lib/app/modules/quality_reporting/valueset_sequence.rb
+++ b/lib/app/modules/quality_reporting/valueset_sequence.rb
@@ -21,6 +21,7 @@ module Inferno
         end
 
         measure_id = @instance.measure_to_test
+        assert measure_id != nil, 'Expected Measure To Test to be defined.'
         valueset_urls = get_all_dependent_valuesets(measure_id)
         missing_valuesets = []
 

--- a/lib/app/modules/quality_reporting/valueset_sequence.rb
+++ b/lib/app/modules/quality_reporting/valueset_sequence.rb
@@ -21,7 +21,7 @@ module Inferno
         end
 
         measure_id = @instance.measure_to_test
-        assert measure_id != nil, 'Expected Measure To Test to be defined.'
+        assert !measure_id.nil?, 'Expected Measure To Test to be defined.'
         valueset_urls = get_all_dependent_valuesets(measure_id)
         missing_valuesets = []
 

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -41,5 +41,72 @@ module Inferno
       }
       LoggedRestClient.post(@instance.url + '/$import', params_resource.to_json, headers)
     end
+
+    def get_required_library_ids(library)
+      refs = library.relatedArtifact.select { |ref| ref.type == 'depends-on'}
+      refs.map { |ref| ref.resource.reference.sub 'Library/', '' }
+    end
+
+    def get_valueset_urls(library)
+      library.dataRequirement.lazy
+                             .select { |dr| dr.codeFilter != nil && dr.codeFilter[0] != nil && dr.codeFilter[0].valueSetString != nil }
+                             .map { |dr| dr.codeFilter[0].valueSetString[/([0-9]+\.)+[0-9]+/] }
+                             .uniq
+                             .to_a
+    end
+
+    def cqf_ruler_client
+      if @_cqf_ruler_client.nil?
+        @_cqf_ruler_client = FHIR::Client.new(Inferno::CQF_RULER)
+      end
+      @_cqf_ruler_client
+    end
+
+    def get_measure_resource(measure_id)
+      measures_endpoint = Inferno::CQF_RULER + 'Measure'
+      measure_request = cqf_ruler_client.client.get("#{measures_endpoint}/#{measure_id}")
+      if measure_request.code != 200
+        raise StandardError.new("Could not retrieve measure #{measure_id} from CQF Ruler.")
+      else
+        return FHIR::STU3::Measure.new JSON.parse(measure_request.body)
+      end
+    end
+
+    def get_library_resource(library_id)
+      libraries_endpoint = Inferno::CQF_RULER + 'Library'
+      library_request = cqf_ruler_client.client.get("#{libraries_endpoint}/#{library_id}")
+      if library_request.code != 200
+        raise StandardError.new("Could not retrieve library #{library_id} from CQF Ruler.")
+      else
+        return FHIR::STU3::Library.new JSON.parse(library_request.body)
+      end
+    end
+
+    def get_all_library_dependent_valuesets(library, visited_ids = [])
+      all_dependent_value_sets = []
+      visited_ids << library.id
+      # iterate over dependent libraries
+      required_library_ids = get_required_library_ids(library)
+      required_library_ids.each do |library_id|
+        unless visited_ids.include?(library_id)
+          all_dependent_value_sets.concat(get_all_library_dependent_valuesets(get_library_resource(library_id), visited_ids))
+        end
+      end
+
+      all_dependent_value_sets.concat(get_valueset_urls(library)).uniq
+    end
+
+    def get_all_dependent_valuesets(measure_id)
+      measure = get_measure_resource(measure_id)
+
+      all_dependent_valuesets = []
+      processed = Set.new
+      # The entry measure has related libraries but no data requirements, so do
+      # one pass before entering the loop
+      main_library_id = measure.library[0].reference.sub('Library/', '')
+      main_library = get_library_resource(main_library_id)
+
+      get_all_library_dependent_valuesets(main_library)
+    end
   end
 end

--- a/test/sequence/quality_reporting/valueset_sequence_test.rb
+++ b/test/sequence/quality_reporting/valueset_sequence_test.rb
@@ -12,11 +12,37 @@ class ValueSetSequenceTest < MiniTest::Test
     'User-Agent' => 'Ruby FHIR Client'
   }.freeze
 
+  CQF_REQUEST_HEADERS = {
+    'Accept'=>'*/*',
+    'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+    'Host'=>'localhost:8080'
+  }.freeze
+
+  # load up the CMS130 'measure-col' bundle to use for testing
+  PROJECT_ROOT = "#{__dir__}/../../.."
+  MEASURE_COL_BUNDLE_PATH = File.expand_path('resources/quality_reporting/CMS130/Bundle/cms130-bundle.json', PROJECT_ROOT)
+  MEASURE_COL_BUNDLE = FHIR::STU3::Bundle.new JSON.parse(File.read(MEASURE_COL_BUNDLE_PATH))
+
   MEASURES_TO_TEST = [
     {
-      measure_id: 'MitreTestScript-measure-col'
+      measure_id: 'MitreTestScript-measure-col',
+      bundle: MEASURE_COL_BUNDLE
     }
   ].freeze
+
+  def stub_measure_resource_requests(measure_info)
+    measure_resource = measure_info[:bundle].entry.select { |e| e.resource.id == 'MitreTestScript-measure-col' }.first.resource
+    stub_request(:get, "http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/#{measure_info[:measure_id]}")
+      .with(headers: CQF_REQUEST_HEADERS)
+      .to_return(status: 200, body: measure_resource.to_json, headers: {})
+
+    library_resources = measure_info[:bundle].entry.select { |e| e.resource.resourceType == 'Library' }.map(&:resource)
+    library_resources.each do |library|
+      stub_request(:get, "http://localhost:8080/cqf-ruler-dstu3/fhir/Library/#{library.id}")
+        .with(headers: CQF_REQUEST_HEADERS)
+        .to_return(status: 200, body: library.to_json, headers: {})
+    end
+  end
 
   def setup
     @instance = Inferno::Models::TestingInstance.new(url: 'http://www.example.com', selected_module: 'quality_reporting')
@@ -30,11 +56,14 @@ class ValueSetSequenceTest < MiniTest::Test
   def test_all_pass
     WebMock.reset!
 
-    MEASURES_TO_TEST.each do
+    MEASURES_TO_TEST.each do |measure_info|
       stub_request(:get, %r{http\:\/\/www\.example\.com\/ValueSet\/([0-9]+\.)+[0-9]+})
         .with(headers: REQUEST_HEADERS)
         .to_return(status: 200, body: '', headers: {})
 
+      stub_measure_resource_requests(measure_info)
+
+      @instance.measure_to_test = measure_info[:measure_id]
       sequence_result = @sequence.start
       assert sequence_result.pass?, 'The sequence should be marked as pass.'
       assert sequence_result.test_results.all? { |r| r.pass? || r.skip? }, 'All tests should pass'
@@ -44,11 +73,14 @@ class ValueSetSequenceTest < MiniTest::Test
   def test_vs_not_found
     WebMock.reset!
 
-    MEASURES_TO_TEST.each do
+    MEASURES_TO_TEST.each do |measure_info|
       stub_request(:get, %r{http\:\/\/www\.example\.com\/ValueSet\/([0-9]+\.)+[0-9]+})
         .with(headers: REQUEST_HEADERS)
         .to_return(status: 404, body: '', headers: {})
 
+      stub_measure_resource_requests(measure_info)
+
+      @instance.measure_to_test = measure_info[:measure_id]
       sequence_result = @sequence.start
       assert sequence_result.fail?, 'The sequence should be marked as fail.'
     end

--- a/test/sequence/quality_reporting/valueset_sequence_test.rb
+++ b/test/sequence/quality_reporting/valueset_sequence_test.rb
@@ -85,4 +85,12 @@ class ValueSetSequenceTest < MiniTest::Test
       assert sequence_result.fail?, 'The sequence should be marked as fail.'
     end
   end
+
+  def test_measure_to_test_not_defined
+    WebMock.reset!
+
+    @instance.measure_to_test = nil
+    sequence_result = @sequence.start
+    assert sequence_result.fail?, 'The sequence should be marked as fail.'
+  end
 end

--- a/test/sequence/quality_reporting/valueset_sequence_test.rb
+++ b/test/sequence/quality_reporting/valueset_sequence_test.rb
@@ -13,9 +13,9 @@ class ValueSetSequenceTest < MiniTest::Test
   }.freeze
 
   CQF_REQUEST_HEADERS = {
-    'Accept'=>'*/*',
-    'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-    'Host'=>'localhost:8080'
+    'Accept' => '*/*',
+    'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+    'Host' => 'localhost:8080'
   }.freeze
 
   # load up the CMS130 'measure-col' bundle to use for testing

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,8 +24,7 @@ def set_global_mocks
         'Accept' => '*/*',
         'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
         'Content-Type' => 'application/json+fhir',
-        'Host' => 'localhost:8080',
-        'User-Agent' => 'rest-client/2.1.0 (darwin18.7.0 x86_64) ruby/2.5.6p201'
+        'Host' => 'localhost:8080'
       }
     )
     .to_return(status: 200, body: '', headers: {})

--- a/test/unit/web_utils_test.rb
+++ b/test/unit/web_utils_test.rb
@@ -6,8 +6,7 @@ class WebUtilsTest < MiniTest::Test
   REQUEST_HEADERS = {
     'Accept' => '*/*',
     'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-    'Host' => 'www.example.com',
-    'User-Agent' => 'rest-client/2.1.0 (darwin18.7.0 x86_64) ruby/2.5.6p201'
+    'Host' => 'www.example.com'
   }.freeze
 
   def test_retry_till_timeout_retry_specified


### PR DESCRIPTION
# Summary
Generic ValueSet Availability Sequence that lets you choose the measure you want to check availability for.

## New behavior
Fetches and parses Measure and Library resources in cqf-ruler to find the specific measure value sets to validate for existence on the system under test.

Fixes issues with WebMock and travis as well.

## Code changes
Added to the measure operation util module to do the fetching and parsing from cqf-ruler to generate the list of value set oids. This recurses through the dependent libraries as needed.

WebMock fixes were just to simply remove the User-Agent in the expected heaters for the stubbed requests.

# Testing guidance
Have cqf-ruler instance populated with more than one measure to prove it can work with multiple measures. ~You may need to fix the reference in the CMS165 Measure that points to the main library to point to the actual library (the id with a version) that has content.~

Use cqf-ruler-preloaded.0.1.3. `docker run --name cqf-ruler --rm -dit -p 8080:8080 artifacts.mitre.org:8200/cqf-ruler-preloaded:0.1.3`