### PR TITLE
Fix Travis Bundler issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 services:
   - docker
 before_install:
-  - gem update --system
-  - gem install bundler
   - docker-compose build
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
# Summary
Bundler was recently updated to 2.1.0. The way we install Bundler was running into a conflict, where 2.1.0 was being installed in one location, while an older version was already installed elsewhere. This removes one of the conflicting versions, so Travis will actually finish.
## New behavior
None
## Code changes
None
# Testing guidance
Ensure the Travis build passes.
