### PR TITLE
Comment out unused sequences

### DIFF
--- a/lib/app/modules/quality_reporting_module.yml
+++ b/lib/app/modules/quality_reporting_module.yml
@@ -15,12 +15,12 @@ test_sets:
         sequences:
           - ResourceSequence
           - SubmitDataSequence
-      - name: CMS165 Bulk Data Reporting
-        sequences:
-          - CMS165BulkDataReportingSequence
-      - name: CMS130 Quality Reporting
-        sequences:
-          - CMS130ReportingSequence
-      - name: CMS165 Quality Reporting
-        sequences:
-          - CMS165ReportingSequence
+      #- name: CMS165 Bulk Data Reporting
+        #sequences:
+          #- CMS165BulkDataReportingSequence
+      #- name: CMS130 Quality Reporting
+        #sequences:
+          #- CMS130ReportingSequence
+      #- name: CMS165 Quality Reporting
+        #sequences:
+          #- CMS165ReportingSequence


### PR DESCRIPTION
# Summary

We have some older non-general sequences still enabled in our quality reporting module. Disabling those to keep the interface cleaner.

## New behavior

Only pre reqs and reporting actions test groups now show up in inferno

## Code changes

Commented out sequences in the module's yml file.

# Testing guidance

Run Inferno and ensure that only the pre reqs and reporting actions groups are there.
