### PR TITLE
Remove selection of measure_to_test in ValueSet sequence

### DIFF
--- a/lib/app/modules/quality_reporting/valueset_sequence.rb
+++ b/lib/app/modules/quality_reporting/valueset_sequence.rb
@@ -10,7 +10,6 @@ module Inferno
       title 'ValueSet Availability'
 
       test_id_prefix 'valueset'
-      requires :measure_to_test
       description 'Ensure that all required value sets for a target measure are available'
 
       test 'Check ValueSet Availability' do
@@ -21,7 +20,7 @@ module Inferno
         end
 
         measure_id = @instance.measure_to_test
-        assert !measure_id.nil?, 'Expected Measure To Test to be defined.'
+        assert !measure_id.nil?, 'Expected Measure To Test to be defined. The Measure Availability Sequence must be performed before this sequence.'
         valueset_urls = get_all_dependent_valuesets(measure_id)
         missing_valuesets = []
 


### PR DESCRIPTION
# Summary
Rather than prompting user to select measure, use the one already selected in the Measure Availability sequence.
https://jira.mitre.org/browse/TACOSTRAT-353

## New behavior
ValueSet Availability sequence no longer has dropdown for selecting measure, but will use the one selected int he measure availability sequence instead.

Tested out with the guided mode that will be incoming later, and works with that in addition to the default mode.
## Code changes
Remove measure_to_test requirement in valueset_sequence and add more descriptive error on test fail.

# Testing guidance
Run sequence in default mode and ensure behavior matches description.

(Optional) If you want to run in guided mode, cherry-pick the change on top of `connectathon-dev` and run locally.