### PR TITLE
Add changes we want from the 2020 Balitmore Connectathon

### DIFF
--- a/lib/app/ext/measure_report.rb
+++ b/lib/app/ext/measure_report.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FHIR
+  module STU3
+    class MeasureReport
+      FHIR::STU3::MeasureReport::METADATA['_type'] = { 'type' => 'code', 'path' => 'MeasureReport._type', 'min' => 0, 'max' => 1 }
+
+      attr_accessor :_type
+    end
+  end
+end

--- a/lib/app/models/module.rb
+++ b/lib/app/models/module.rb
@@ -16,6 +16,7 @@ module Inferno
     attr_accessor :name
     attr_accessor :test_sets
     attr_accessor :title
+    attr_accessor :measures
 
     def initialize(params)
       @name = params[:name]
@@ -83,9 +84,7 @@ module Inferno
       measures_endpoint = Inferno::CQF_RULER + 'Measure'
       resp = cqf_ruler_client.client.get(measures_endpoint, headers)
       bundle = FHIR::STU3::Bundle.new JSON.parse(resp.body)
-      measure_resources = bundle.entry.select { |e| e.resource.class == FHIR::STU3::Measure }
-      measure_ids = measure_resources.map { |measure| measure.resource.id }
-      @measures = measure_ids
+      @measures = bundle.entry.select { |e| e.resource.class == FHIR::STU3::Measure }
     rescue StandardError
       @measures = []
     end

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -56,6 +56,10 @@ module Inferno
 
       property :must_support_confirmed, String, default: ''
 
+      # Auth credentials
+      property :api_key, String
+      property :auth_header, String
+
       has n, :sequence_results
       has n, :resource_references
       has 1, :server_capabilities

--- a/lib/app/modules/quality_reporting/measure_availability_sequence.rb
+++ b/lib/app/modules/quality_reporting/measure_availability_sequence.rb
@@ -26,7 +26,7 @@ module Inferno
         measure_id = @instance.measure_to_test
         measure_resource = @instance.module.measures.find { |m| m.resource.id == measure_id }
 
-        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header }
+        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
 
         # Search system for measure by identifier and version
         measure_identifier = measure_resource.resource.identifier.find { |id| id.system == 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms' }

--- a/lib/app/modules/quality_reporting/measure_availability_sequence.rb
+++ b/lib/app/modules/quality_reporting/measure_availability_sequence.rb
@@ -11,7 +11,7 @@ module Inferno
       title 'Measure Availability'
 
       test_id_prefix 'measure_availability'
-      requires :measure_to_test
+      requires :measure_to_test, :api_key, :auth_header
 
       description 'Ensure that a specific measure exists on test server'
 
@@ -21,9 +21,21 @@ module Inferno
           link 'https://www.hl7.org/fhir/measure.html'
           desc 'Check to make sure specified measure is available on test server'
         end
+
+        # Look for matching measure from cqf-ruler datastore by resource id
         measure_id = @instance.measure_to_test
-        query_response = @client.search(FHIR::Measure, search: { parameters: { _id: measure_id } })
+        measure_resource = @instance.module.measures.find { |m| m.resource.id == measure_id }
+
+        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header }
+
+        # Search system for measure by identifier and version
+        measure_identifier = measure_resource.resource.identifier.find { |id| id.system == 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms' }
+        measure_version = measure_resource.resource.version
+        query_response = @client.search(FHIR::Measure, search: { parameters: { identifier: measure_identifier.value, version: measure_version } })
         assert_equal query_response.resource.total, 1, "Expected to find measure with id #{measure_id}"
+
+        # Update instance variable to be the ID we get back from the SUT
+        @instance.measure_to_test = query_response.resource.entry.first.resource.id
       end
     end
   end

--- a/lib/app/modules/quality_reporting/resource_sequence.rb
+++ b/lib/app/modules/quality_reporting/resource_sequence.rb
@@ -22,6 +22,8 @@ module Inferno
           desc 'Add a resource using a POST request, then verify it is available'
         end
 
+        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
+
         id_string = SecureRandom.uuid
         observation = FHIR::Observation.new
         identifier = FHIR::Identifier.new value: id_string

--- a/lib/app/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/app/modules/quality_reporting/submit_data_sequence.rb
@@ -23,13 +23,13 @@ module Inferno
 
         assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running Reporting Actions sequences.')
 
-        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header }
+        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
 
         # Get the patient data to submit. We currently support cms124, cms130, cms165 only
         patient_bundle_path = case @instance.measure_to_test
-                              when 'measure-exm124-FHIR3'
+                              when 'measure-EXM124-FHIR3-7.2.000'
                                 '../../../../resources/quality_reporting/CMS124/Bundle/cms124-patient-bundle.json'
-                              when 'measure-exm130-FHIR3'
+                              when 'measure-EXM130-FHIR3-7.2.000'
                                 '../../../../resources/quality_reporting/CMS130/Bundle/cms130-patient-bundle.json'
                                 # when 'measure-exm165-FHIR3'
                                 # '../../../../resources/quality_reporting/CMS165/Bundle/cms165-patient-bundle.json'

--- a/lib/app/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/app/modules/quality_reporting/submit_data_sequence.rb
@@ -22,6 +22,9 @@ module Inferno
         end
 
         assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running Reporting Actions sequences.')
+
+        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header }
+
         # Get the patient data to submit. We currently support cms124, cms130, cms165 only
         patient_bundle_path = case @instance.measure_to_test
                               when 'measure-exm124-FHIR3'

--- a/lib/app/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/app/modules/quality_reporting/submit_data_sequence.rb
@@ -27,9 +27,9 @@ module Inferno
 
         # Get the patient data to submit. We currently support cms124, cms130, cms165 only
         patient_bundle_path = case @instance.measure_to_test
-                              when 'measure-EXM124-FHIR3-7.2.000'
+                              when 'measure-EXM124-FHIR3-7.2.000', 'measure-exm124-FHIR3'
                                 '../../../../resources/quality_reporting/CMS124/Bundle/cms124-patient-bundle.json'
-                              when 'measure-EXM130-FHIR3-7.2.000'
+                              when 'measure-EXM130-FHIR3-7.2.000', 'measure-exm130-FHIR3'
                                 '../../../../resources/quality_reporting/CMS130/Bundle/cms130-patient-bundle.json'
                                 # when 'measure-exm165-FHIR3'
                                 # '../../../../resources/quality_reporting/CMS165/Bundle/cms165-patient-bundle.json'

--- a/lib/app/modules/quality_reporting/valueset_sequence.rb
+++ b/lib/app/modules/quality_reporting/valueset_sequence.rb
@@ -19,6 +19,8 @@ module Inferno
           desc 'Expand each Value Set in a measure to ensure they are available'
         end
 
+        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
+
         measure_id = @instance.measure_to_test
         assert !measure_id.nil?, 'Expected Measure To Test to be defined. The Measure Availability Sequence must be performed before this sequence.'
         valueset_urls = get_all_dependent_valuesets(measure_id)

--- a/lib/app/modules/quality_reporting_module.yml
+++ b/lib/app/modules/quality_reporting_module.yml
@@ -8,10 +8,12 @@ test_sets:
     view: guided
     tests:
       - name: Prerequisites
+        overview: The server satisfies prerequisite state for quality reporting.
         sequences:
           - MeasureAvailability
           - ValueSetSequence
       - name: Reporting Actions
+        overview: The server correctly handles reporting actions.
         sequences:
           - ResourceSequence
           - SubmitDataSequence

--- a/lib/app/modules/quality_reporting_module.yml
+++ b/lib/app/modules/quality_reporting_module.yml
@@ -5,7 +5,7 @@ default_test_set: developer
 fhir_version: stu3
 test_sets:
   developer:
-    view: default
+    view: guided
     tests:
       - name: Prerequisites
         sequences:

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -55,7 +55,9 @@ module Inferno
 
       headers = {
         content_type: 'application/json'
-      }.merge(@client.additional_headers)
+      }
+
+      headers.merge!(@client.additional_headers) if @client.additional_headers
 
       @client.post("Measure/#{measure_id}/$submit-data", parameters, headers)
     end

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+require_relative '../ext/measure_report'
 
 module Inferno
   module MeasureOperations
@@ -16,6 +17,14 @@ module Inferno
     def create_measure_report(measure_id, patient_id, period_start, period_end)
       FHIR::STU3::MeasureReport.new.from_hash(
         type: 'individual',
+        _type: {
+          'extension': [
+            {
+              'url': 'https://www.hl7.org/fhir/measurereport-definitions.html#MeasureReport.type',
+              'valueString': 'data-collection'
+            }
+          ]
+        },
         identifier: [{
           value: SecureRandom.uuid
         }],
@@ -46,7 +55,7 @@ module Inferno
 
       headers = {
         content_type: 'application/json'
-      }
+      }.merge!(@client.additional_headers)
 
       @client.post("Measure/#{measure_id}/$submit-data", parameters, headers)
     end

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -55,7 +55,7 @@ module Inferno
 
       headers = {
         content_type: 'application/json'
-      }.merge!(@client.additional_headers)
+      }.merge(@client.additional_headers)
 
       @client.post("Measure/#{measure_id}/$submit-data", parameters, headers)
     end

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -232,6 +232,16 @@
               instance: instance,
               value: instance.measure_to_test,
               })%>
+        <%= erb(:prerequisite_field,{},{prerequisite: :api_key,
+              label: 'API Key',
+              instance: instance,
+              value: instance.api_key,
+              })%>
+        <%= erb(:prerequisite_field,{},{prerequisite: :auth_header,
+              label: 'Authorization Header',
+              instance: instance,
+              value: instance.auth_header,
+              })%>
       </div>
       <form method="POST" action="sequence_result">
         <input type="hidden" name="sequence" value="" />

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -343,6 +343,22 @@
 
         </div>
 
+        <%= erb(:prerequisite_field_dropdown,{},{prerequisite: :measure_to_test,
+              label: 'Measure To Test',
+              instance: instance,
+              value: instance.measure_to_test,
+              })%>
+        <%= erb(:prerequisite_field,{},{prerequisite: :api_key,
+              label: 'API Key',
+              instance: instance,
+              value: instance.api_key,
+              })%>
+        <%= erb(:prerequisite_field,{},{prerequisite: :auth_header,
+              label: 'Authorization Header',
+              instance: instance,
+              value: instance.auth_header,
+              })%>
+
         <%= erb(:prerequisite_field,{},{prerequisite: :client_secret,
               label: 'Client Secret',
               instance: instance,

--- a/lib/app/views/prerequisite_field_dropdown.erb
+++ b/lib/app/views/prerequisite_field_dropdown.erb
@@ -18,7 +18,9 @@
     <div class="form-group">
         <select class="custom-select custom-select-lg" name="<%=prerequisite.to_s%>" style="margin-left: 10px;" id="<%=prerequisite.to_s%>"">
         <% instance.module.testable_measures.each do |measure| %>
-            <option value=<%=measure.resource.id%>> <%=measure.resource.id%> </option>
+            <% if id = measure.resource.identifier.find { |id| id.system == 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms' } %>
+              <option value=<%=measure.resource.id%>> <%= "CMS#{id.value} v#{measure.resource.version}" %> </option>
+            <% end %>
         <% end %>
         <input type="hidden" name="prerequisite_input" id="prerequisite_input" value=<%=value%> />
         </select>

--- a/lib/app/views/prerequisite_field_dropdown.erb
+++ b/lib/app/views/prerequisite_field_dropdown.erb
@@ -18,7 +18,7 @@
     <div class="form-group">
         <select class="custom-select custom-select-lg" name="<%=prerequisite.to_s%>" style="margin-left: 10px;" id="<%=prerequisite.to_s%>"">
         <% instance.module.testable_measures.each do |measure| %>
-            <option value=<%=measure%>> <%=measure%> </option>
+            <option value=<%=measure.resource.id%>> <%=measure.resource.id%> </option>
         <% end %>
         <input type="hidden" name="prerequisite_input" id="prerequisite_input" value=<%=value%> />
         </select>

--- a/test/fixtures/exm130_get_measure_resource.json
+++ b/test/fixtures/exm130_get_measure_resource.json
@@ -1,80 +1,160 @@
 {
   "resourceType": "Bundle",
-  "id": "7e75b287-9d86-450a-98d2-0df3727a2466",
-  "meta": {
-    "lastUpdated": "2019-09-19T15:03:19.772+00:00"
-  },
+  "id": "8a444bb9-898f-4d0b-a1b3-c78c11e9fa42",
   "type": "searchset",
   "total": 1,
-  "link": [
-    {
-      "relation": "self",
-      "url": "http://localhost:8080/cqf-ruler-dstu3/fhir/Measure?_sort=_lastUpdated&name=EXM130"
-    }
-  ],
   "entry": [
     {
-      "fullUrl": "http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/MitreTestScript-measure-col",
       "resource": {
         "resourceType": "Measure",
-        "id": "MitreTestScript-measure-col",
+        "id": "measure-exm130-FHIR3",
         "meta": {
           "versionId": "1",
-          "lastUpdated": "2019-09-19T15:03:04.662+00:00"
+          "lastUpdated": "2020-01-08T02:19:01.753+00:00",
+          "profile": [
+            "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/proportion-measure-cqfm"
+          ]
         },
-        "text": {
-          "status": "generated"
-        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-populationBasis",
+            "valueCode": "boolean"
+          }
+        ],
+        "url": "http://hl7.org/fhir/us/cqfmeasures/Measure/measure-exm130-FHIR3",
         "identifier": [
           {
             "use": "official",
-            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/payer-extract",
-            "value": "COL"
+            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms",
+            "value": "130"
+          },
+          {
+            "use": "official",
+            "system": "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/nqf",
+            "value": "0034"
           }
         ],
-        "version": "1.0.0",
+        "version": "7.2.000",
         "name": "EXM130",
-        "title": "Colorectal Cancer Screening. Cohort Definition",
+        "title": "Colorectal Cancer Screening",
         "status": "active",
         "experimental": true,
-        "date": "2015-03-08",
-        "description": "Colorectal Cancer Screening. Cohort Definition",
-        "topic": [
+        "date": "2018-08-28",
+        "publisher": "National Committee for Quality Assurance",
+        "description": "Percentage of adults 50-75 years of age who had appropriate screening for colorectal cancer",
+        "purpose": "Patients 50-75 years of age with a visit during the measurement period",
+        "approvalDate": "2016-01-01",
+        "lastReviewDate": "2016-09-01",
+        "effectivePeriod": {
+          "start": "2018-01-01",
+          "end": "2018-12-31"
+        },
+        "useContext": [
+          {
+            "code": {
+              "code": "program"
+            },
+            "valueCodeableConcept": {
+              "text": "eligible-provider"
+            }
+          }
+        ],
+        "jurisdiction": [
           {
             "coding": [
               {
-                "system": "http://hl7.org/fhir/c80-doc-typecodes",
-                "code": "57024-2"
+                "system": "urn:iso:std:iso:3166",
+                "code": "US"
               }
             ]
           }
         ],
-        "library": [
+        "topic": [
           {
-            "reference": "Library/MitreTestScript-library-col-logic"
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "57024-2",
+                "display": "Health Quality Measure Document"
+              }
+            ]
           }
         ],
+        "contributor": [
+          {
+            "type": "author",
+            "name": "National Committee for Quality Assurance"
+          }
+        ],
+        "contact": [
+          {
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.ncqa.org/"
+              }
+            ]
+          }
+        ],
+        "copyright": "This Physician Performance Measure (Measure) and related data specifications were developed by the National Committee for Quality Assurance (NCQA). NCQA is not responsible for any use of the Measure. NCQA makes no representations, warranties, or endorsement about the quality of any organization or physician that uses or reports performance measures and NCQA has no liability to anyone who relies on such measures or specifications. NCQA holds a copyright in the Measure. The Measure can be reproduced and distributed, without modification, for noncommercial purposes (eg, use by healthcare providers in connection with their practices) without obtaining approval from NCQA. Commercial use is defined as the sale, licensing, or distribution of the Measure for commercial gain, or incorporation of the Measure into a product or service that is sold, licensed or distributed for commercial gain. All commercial uses or requests for modification must be approved by NCQA and are subject to a license at the discretion of NCQA. (C) 2012-2017 National Committee for Quality Assurance. All Rights Reserved. Limited proprietary coding is contained in the Measure specifications for user convenience. Users of proprietary code sets should obtain all necessary licenses from the owners of the code sets. NCQA disclaims all liability for use or accuracy of any third party codes contained in the specifications. CPT(R) contained in the Measure specifications is copyright 2004-2017 American Medical Association. LOINC(R) copyright 2004-2017 Regenstrief Institute, Inc. This material contains SNOMED Clinical Terms(R) (SNOMED CT[R] ) copyright 2004-2017 International Health Terminology Standards Development Organisation. ICD-10 copyright 2017 World Health Organization. All Rights Reserved.",
+        "relatedArtifact": [
+          {
+            "type": "citation",
+            "citation": "U.S. Preventive Services Task Force. \"Screening for Colorectal Cancer: U.S. Preventive Services Task Force Recommendation Statement.\" JAMA, vol. 315, no. 23, 2016, pp. 2564-2575. doi: 10.1001/jama.2016.5989"
+          },
+          {
+            "type": "citation",
+            "citation": "Howlader, N., A.M. Noone, M. Krapcho, D. Miller, K. Bishop, C.L. Kosary, M. Yu, J. Ruhl, Z. Tatalovich, A. Mariotto, D.R. Lewis, H.S. Chen, E.J. Feuer, and K.A. Cronin. \"SEER Cancer Statistics Review, 1975-2014.\" Washington, DC: National Cancer Institute, 2017. Available at https://seer.cancer.gov/csr/1975_2014/"
+          },
+          {
+            "type": "citation",
+            "citation": "American Cancer Society. \"Can Colorectal Polyps and Cancer Be Found Early?\" Last modified March 2017. Washington, DC: American Cancer Society. Available at https://www.cancer.org/cancer/colon-rectal-cancer/detection-diagnosis-staging/detection.html."
+          }
+        ],
+        "library": [
+          {
+            "reference": "Library/library-exm130-FHIR3"
+          }
+        ],
+        "disclaimer": "The performance Measure is not a clinical guideline and does not establish a standard of medical care, and has not been tested for all potential applications. THE MEASURE AND SPECIFICATIONS ARE PROVIDED \"AS IS\" WITHOUT WARRANTY OF ANY KIND. Due to technical limitations, registered trademarks are indicated by (R) or [R] and unregistered trademarks are indicated by (TM) or [TM].",
         "scoring": {
           "coding": [
             {
+              "system": "http://hl7.org/fhir/measure-scoring",
               "code": "proportion"
             }
           ]
         },
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/measure-type",
+                "code": "process"
+              }
+            ]
+          }
+        ],
+        "rationale": "Colorectal cancer represents 8 percent of all new cancer cases and is the second leading cause of cancer deaths in the United States. In 2017, there were an estimated 135,430 new cases of colorectal cancer and an estimated 50,260 deaths attributed to it. According to the National Cancer Institute, about 4.3 percent of men and women will be diagnosed with colorectal cancer at some point during their lifetimes. For most adults, older age is the most important risk factor for colorectal cancer, although being male and black are also associated with higher incidence and mortality. Colorectal cancer is most frequently diagnosed among people 65 to 74 years old (Howlader et al. 2017). Screening can be effective for finding precancerous lesions (polyps) that could later become malignant, and for detecting early cancers that can be more easily and effectively treated. Precancerous polyps usually take about 10 to 15 years to develop into colorectal cancer, and most can be found and removed before turning into cancer. The five-year relative survival rate for people whose colorectal cancer is found in the early stage before it has spread is about 90 percent (American Cancer Society 2017).",
+        "clinicalRecommendationStatement": "The U. S. Preventive Services Task Force (2016) recommends screening for colorectal cancer starting at age 50 years and continuing until age 75 years. This is a Grade A recommendation (U.S. Preventive Services Task Force 2016). Screening tests: -Colonoscopy (every 10 years) -Flexible sigmoidoscopy (every 5 years) -Fecal occult blood test (annually) -FIT-DNA (every 3 years) -Computed tomographic colonography (every 5 years)",
+        "improvementNotation": "increase",
+        "guidance": "Patient self-report for procedures as well as diagnostic studies should be recorded in \"Procedure, Performed\" template or \"Diagnostic Study, Performed\" template in QRDA-1. Do not count DRE, FOBT tests performed in an office setting or performed on a sample collected via DRE.",
         "group": [
           {
             "identifier": {
-              "value": "COL-cohort"
+              "value": "group-1"
             },
             "population": [
               {
                 "identifier": {
-                  "value": "initial-population"
+                  "value": "initial-population-identifier"
                 },
                 "code": {
                   "coding": [
                     {
-                      "code": "initial-population"
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "initial-population",
+                      "display": "Initial Population"
                     }
                   ]
                 },
@@ -82,12 +162,14 @@
               },
               {
                 "identifier": {
-                  "value": "numerator"
+                  "value": "numerator-identifier"
                 },
                 "code": {
                   "coding": [
                     {
-                      "code": "numerator"
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "numerator",
+                      "display": "Numerator"
                     }
                   ]
                 },
@@ -95,18 +177,101 @@
               },
               {
                 "identifier": {
-                  "value": "denominator"
+                  "value": "denominator-identifier"
                 },
                 "code": {
                   "coding": [
                     {
-                      "code": "denominator"
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "denominator",
+                      "display": "Denominator"
                     }
                   ]
                 },
                 "criteria": "Denominator"
+              },
+              {
+                "identifier": {
+                  "value": "denominator-exclusions-identifier"
+                },
+                "code": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                      "code": "denominator-exclusion",
+                      "display": "Denominator Exclusion"
+                    }
+                  ]
+                },
+                "criteria": "Denominator Exclusion"
               }
             ]
+          }
+        ],
+        "supplementalData": [
+          {
+            "identifier": {
+              "value": "sde-ethnicity"
+            },
+            "usage": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/measure-data-usage",
+                    "code": "supplemental-data"
+                  }
+                ]
+              }
+            ],
+            "criteria": "SDE Ethnicity"
+          },
+          {
+            "identifier": {
+              "value": "sde-payer"
+            },
+            "usage": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/measure-data-usage",
+                    "code": "supplemental-data"
+                  }
+                ]
+              }
+            ],
+            "criteria": "SDE Payer"
+          },
+          {
+            "identifier": {
+              "value": "sde-race"
+            },
+            "usage": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/measure-data-usage",
+                    "code": "supplemental-data"
+                  }
+                ]
+              }
+            ],
+            "criteria": "SDE Race"
+          },
+          {
+            "identifier": {
+              "value": "sde-sex"
+            },
+            "usage": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/measure-data-usage",
+                    "code": "supplemental-data"
+                  }
+                ]
+              }
+            ],
+            "criteria": "SDE Sex"
           }
         ]
       },

--- a/test/sequence/quality_reporting/submit_data_sequence_test.rb
+++ b/test/sequence/quality_reporting/submit_data_sequence_test.rb
@@ -15,10 +15,10 @@ class SubmitDataSequenceTest < MiniTest::Test
 
   MEASURES_TO_TEST = [
     {
-      measure_id: 'measure-exm124-FHIR3'
+      measure_id: 'measure-EXM124-FHIR3-7.2.000'
     },
     {
-      measure_id: 'measure-exm130-FHIR3'
+      measure_id: 'measure-EXM130-FHIR3-7.2.000'
     }
   ].freeze
 


### PR DESCRIPTION
# Summary
Changes made at the connectathon by @mgramigna and me. Hand selected changes we want to keep from our [connectathon-dev](https://github.com/projecttacoma/deqm-test-client/tree/connectathon-dev) branch.
## New behavior
- User now prompted for auth information. For now this is just an API key and Authorization header. This is NOT a full OAuth workflow, but rather a sort of "workaround" we can use to test against the pilot.
- The Measure Availability sequence now keys on CMS `identifier` and `version` rather than resource `id`. This makes more sense, because resource IDs on the servers might not match our fixtures.
- Quality Reporting module now set to guided view.
## Code changes
- Add authorization inputs
- Add support for STU3 MeasureReport _type extension
- Enhance measure search to use identifier and version, rather than ID
- Switch to Inferno's guided view
- Update unit tests

# Testing guidance
- `bundle exec rake test`
- Manually test by running Inferno with a CQF Ruler instance on localhost, using https://github.com/projecttacoma/docker-deqm-test-client/pull/8. Measure Availability and $submit-data sequences should pass for EXM124 and EXM130. Inputting auth information should be optional and unnecessary unless running against a pilot instance.