### PR TITLE
Measure evaluation sequence

### DIFF
--- a/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
+++ b/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
@@ -15,7 +15,6 @@ module Inferno
 
       description 'Ensure that measure report returned by the $evaluate-measure operation for selected measure is correct'
 
-      requires :measure_to_test
       # Parameters appended to the url for $evaluate-measure call
       PARAMS = {
         'periodStart': '2019-01-01',
@@ -29,6 +28,7 @@ module Inferno
         end
 
         measure_id = @instance.measure_to_test
+        assert !measure_id.nil?, 'Expected Measure To Test to be defined. The Measure Availability Sequence must be performed before this sequence.'
 
         # Get measure report from cqf-ruler and build expected results
         expected_results_report = get_measure_evaluation(measure_id, PARAMS.compact)

--- a/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
+++ b/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
@@ -13,10 +13,14 @@ module Inferno
 
       test_id_prefix 'evaluate_measure'
 
-      description 'Ensure that measure report returned by $evaluate-measure operation for selected measure is correct'
+      description 'Ensure that measure report returned by the $evaluate-measure operation for selected measure is correct'
 
       requires :measure_to_test
-
+      # Parameters appended to the url for $evaluate-measure call
+      PARAMS = {
+        'periodStart': '2019-01-01',
+        'periodEnd': '2019-12-31'
+      }.freeze
       test 'Evaluate Measure' do
         metadata do
           id '01'
@@ -24,15 +28,7 @@ module Inferno
           desc 'Run the $evaluate-measure operation for a measure, results should match those reported by CQF-Ruler'
         end
 
-        period_start = '2019-01-01'
-        period_end = '2019-12-31'
         measure_id = @instance.measure_to_test
-
-        # Parameters appended to the url for $evaluate-measure call
-        PARAMS = {
-          'periodStart': period_start,
-          'periodEnd': period_end
-        }.freeze
 
         # Get measure report from cqf-ruler and build expected results
         expected_results_report = get_measure_evaluation(measure_id, PARAMS.compact)

--- a/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
+++ b/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
@@ -3,13 +3,11 @@
 require_relative '../../utils/measure_operations'
 require_relative '../../utils/bundle'
 
-
 module Inferno
   module Sequence
     class MeasureEvaluationSequence < SequenceBase
       include MeasureOperations
       include BundleParserUtil
-
 
       title 'Measure Evaluation'
 
@@ -18,7 +16,6 @@ module Inferno
       description 'Ensure that measure report returned by $evaluate-measure operation for selected measure is correct'
 
       requires :measure_to_test
-
 
       test 'Evaluate Measure' do
         metadata do
@@ -37,16 +34,15 @@ module Inferno
           'periodEnd': period_end
         }.freeze
 
-
         # Get measure report from cqf-ruler and build expected results
         expected_results_report = get_measure_evaluation(measure_id, PARAMS.compact)
         expected_results = {}
         expected_results_report.group.each do |group|
-            group.population.each do |population|
-                name = population.code.coding[0].code
-                count = population.count
-                expected_results[name] = count
-            end
+          group.population.each do |population|
+            name = population.code.coding[0].code
+            count = population.count
+            expected_results[name] = count
+          end
         end
 
         evaluate_measure_response = evaluate_measure(measure_id, PARAMS.compact)

--- a/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
+++ b/lib/app/modules/quality_reporting/measure_evaluation_sequence.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative '../../utils/measure_operations'
+require_relative '../../utils/bundle'
+
+
+module Inferno
+  module Sequence
+    class MeasureEvaluationSequence < SequenceBase
+      include MeasureOperations
+      include BundleParserUtil
+
+
+      title 'Measure Evaluation'
+
+      test_id_prefix 'evaluate_measure'
+
+      description 'Ensure that measure report returned by $evaluate-measure operation for selected measure is correct'
+
+      requires :measure_to_test
+
+
+      test 'Evaluate Measure' do
+        metadata do
+          id '01'
+          link 'https://hl7.org/fhir/STU3/measure-operations.html#evaluate-measure'
+          desc 'Run the $evaluate-measure operation for a measure, results should match those reported by CQF-Ruler'
+        end
+
+        period_start = '2019-01-01'
+        period_end = '2019-12-31'
+        measure_id = @instance.measure_to_test
+
+        # Parameters appended to the url for $evaluate-measure call
+        PARAMS = {
+          'periodStart': period_start,
+          'periodEnd': period_end
+        }.freeze
+
+
+        # Get measure report from cqf-ruler and build expected results
+        expected_results_report = get_measure_evaluation(measure_id, PARAMS.compact)
+        expected_results = {}
+        expected_results_report.group.each do |group|
+            group.population.each do |population|
+                name = population.code.coding[0].code
+                count = population.count
+                expected_results[name] = count
+            end
+        end
+
+        evaluate_measure_response = evaluate_measure(measure_id, PARAMS.compact)
+        assert_response_ok evaluate_measure_response
+
+        # Load response body into a FHIR MeasureReport class
+        measure_report = FHIR::STU3.from_contents(evaluate_measure_response.body)
+        group = measure_report&.group
+        assert(!group.nil?)
+
+        # Check matching values for each population in the group
+        group&.first&.population&.each do |p|
+          coding = p.code&.coding
+          assert(!coding.nil?)
+          code = coding.first.code
+          assert(!code.nil?)
+          assert_equal(expected_results[code], p.count, "Expected #{code} count and actual #{code} count are not equal") if expected_results.key?(code)
+        end
+      end
+    end
+  end
+end

--- a/lib/app/modules/quality_reporting_module.yml
+++ b/lib/app/modules/quality_reporting_module.yml
@@ -15,6 +15,7 @@ test_sets:
         sequences:
           - ResourceSequence
           - SubmitDataSequence
+          - MeasureEvaluationSequence
       #- name: CMS165 Bulk Data Reporting
         #sequences:
           #- CMS165BulkDataReportingSequence

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -104,6 +104,15 @@ module Inferno
       FHIR::STU3::Measure.new JSON.parse(measure_request.body)
     end
 
+    def get_measure_evaluation(measure_id, params = {})
+      measure_evaluation_endpoint = Inferno::CQF_RULER + 'Measure'
+      params_string = params.empty? ? '' : "?#{params.to_query}"
+      evaluation_response = cqf_ruler_client.client.get("#{measure_evaluation_endpoint}/#{measure_id}/$evaluate-measure#{params_string}")
+      raise StandardError, "Could not retrieve measure_evaluation #{measure_id} from CQF Ruler." if evaluation_response.code != 200
+
+      FHIR::STU3::MeasureReport.new JSON.parse(evaluation_response.body)
+    end
+
     def get_library_resource(library_id)
       libraries_endpoint = Inferno::CQF_RULER + 'Library'
       library_request = cqf_ruler_client.client.get("#{libraries_endpoint}/#{library_id}")

--- a/test/fixtures/col_measure_report_all_zero.json
+++ b/test/fixtures/col_measure_report_all_zero.json
@@ -1,0 +1,225 @@
+{
+    "resourceType": "MeasureReport",
+    "contained": [
+        {
+            "resourceType": "Bundle",
+            "id": "b540a2dc-b6e4-42f2-b335-b89d265981ae",
+            "type": "collection",
+            "entry": [
+                {
+                    "fullUrl": "4d7180cc-73f4-47e3-9b06-5b3327940867",
+                    "resource": {
+                        "resourceType": "List",
+                        "id": "4d7180cc-73f4-47e3-9b06-5b3327940867",
+                        "title": "initial-population",
+                        "entry": [
+                            {
+                                "item": {
+                                    "reference": "#Patient/MitreTestScript-test-Patient-410/_history/1"
+                                }
+                            }
+                        ]
+                    }
+                },
+                {
+                    "fullUrl": "Patient/MitreTestScript-test-Patient-410/_history/1",
+                    "resource": {
+                        "resourceType": "Patient",
+                        "id": "MitreTestScript-test-Patient-410",
+                        "meta": {
+                            "versionId": "1",
+                            "lastUpdated": "2019-07-08T15:34:46.564-04:00",
+                            "profile": [
+                                "http://hl7.org/fhir/us/hedis/StructureDefinition/hedis-patient"
+                            ],
+                            "tag": [
+                                {
+                                    "system": "http://projectcrucible.org",
+                                    "code": "testdata"
+                                }
+                            ]
+                        },
+                        "text": {
+                            "status": "generated",
+                            "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\">Bobbie Simon <b>JACKSON </b></div><table class=\"hapiPropertyTable\"><tbody><tr><td>Identifier</td><td>000000410</td></tr><tr><td>Address</td><td><span>34 SW Thames Avenue </span><br/><span>Unit 4 </span><br/><span>Owosso </span><span>MI </span></td></tr><tr><td>Date of birth</td><td><span>15 June 1955</span></td></tr></tbody></table></div>"
+                        },
+                        "extension": [
+                            {
+                                "url": "http://mihin.org/extension/copyright",
+                                "valueString": "Copyright 2014-2018 Michigan Health Information Network Shared Services. Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License. You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0.  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://hl7.org/fhir/v3/Race",
+                                            "code": "2106-3",
+                                            "display": "White"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://hl7.org/fhir/v3/Ethnicity",
+                                            "code": "2186-5",
+                                            "display": "Not Hispanic or Latino"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-religion",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "http://hl7.org/fhir/v3/ReligiousAffiliation",
+                                            "code": "1077",
+                                            "display": "Protestant"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "identifier": [
+                            {
+                                "use": "official",
+                                "type": {
+                                    "coding": [
+                                        {
+                                            "system": "http://hl7.org/fhir/identifier-type",
+                                            "code": "SB",
+                                            "display": "Social Beneficiary Identifier"
+                                        }
+                                    ]
+                                },
+                                "system": "http://hl7.org/fhir/sid/us-ssn",
+                                "value": "000000410"
+                            },
+                            {
+                                "use": "official",
+                                "type": {
+                                    "coding": [
+                                        {
+                                            "system": "http://hl7.org/fhir/identifier-type",
+                                            "code": "SB",
+                                            "display": "Social Beneficiary Identifier"
+                                        }
+                                    ]
+                                },
+                                "system": "http://mihin.org/fhir/cks",
+                                "value": "9612010d2fc541ee8c77392c05b53e09"
+                            }
+                        ],
+                        "active": true,
+                        "name": [
+                            {
+                                "family": "Jackson",
+                                "given": [
+                                    "Bobbie",
+                                    "Simon"
+                                ]
+                            }
+                        ],
+                        "telecom": [
+                            {
+                                "system": "phone",
+                                "value": "989-555-4735",
+                                "use": "home"
+                            },
+                            {
+                                "system": "phone",
+                                "value": "989-555-0975",
+                                "use": "mobile"
+                            }
+                        ],
+                        "gender": "female",
+                        "birthDate": "1955-06-15",
+                        "address": [
+                            {
+                                "use": "home",
+                                "type": "postal",
+                                "line": [
+                                    "34 SW Thames Avenue",
+                                    "Unit 4"
+                                ],
+                                "city": "Owosso",
+                                "district": "Shiawassee County",
+                                "state": "MI",
+                                "postalCode": "48867"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "status": "complete",
+    "type": "individual",
+    "measure": {
+        "reference": "Measure/MitreTestScript-measure-col"
+    },
+    "patient": {
+        "reference": "Patient/MitreTestScript-test-Patient-410"
+    },
+    "period": {
+        "start": "2017-01-01T00:00:00-05:00",
+        "end": "2017-01-31T00:00:00-05:00"
+    },
+    "group": [
+        {
+            "identifier": {
+                "value": "COL-cohort"
+            },
+            "population": [
+                {
+                    "identifier": {
+                        "value": "initial-population"
+                    },
+                    "code": {
+                        "coding": [
+                            {
+                                "code": "initial-population"
+                            }
+                        ]
+                    },
+                    "count": 0
+                },
+                {
+                    "identifier": {
+                        "value": "numerator"
+                    },
+                    "code": {
+                        "coding": [
+                            {
+                                "code": "numerator"
+                            }
+                        ]
+                    },
+                    "count": 0
+                },
+                {
+                    "identifier": {
+                        "value": "denominator"
+                    },
+                    "code": {
+                        "coding": [
+                            {
+                                "code": "denominator"
+                            }
+                        ]
+                    },
+                    "count": 0
+                }
+            ],
+            "measureScore": 0
+        }
+    ],
+    "evaluatedResources": {
+        "reference": "#b540a2dc-b6e4-42f2-b335-b89d265981ae"
+    }
+}

--- a/test/sequence/quality_reporting/measure_evaluation_test.rb
+++ b/test/sequence/quality_reporting/measure_evaluation_test.rb
@@ -28,6 +28,9 @@ class MeasureEvaluationSequenceTest < MiniTest::Test
       stub_request(:get, /\$evaluate-measure/)
         .to_return(status: 200, body: measure_report.to_json, headers: {})
     end
+    sequence_result = @sequence.start
+    assert sequence_result.pass?, 'The sequence should be marked as pass.'
+    assert sequence_result.test_results.all? { |r| r.pass? || r.skip? }, 'All tests should pass'
   end
 
   def test_evaluate_measure_fail_mismatched_population_counts

--- a/test/sequence/quality_reporting/measure_evaluation_test.rb
+++ b/test/sequence/quality_reporting/measure_evaluation_test.rb
@@ -27,10 +27,11 @@ class MeasureEvaluationSequenceTest < MiniTest::Test
       # Mock a request for $evaluate-measure
       stub_request(:get, /\$evaluate-measure/)
         .to_return(status: 200, body: measure_report.to_json, headers: {})
+
+      sequence_result = @sequence.start
+      assert sequence_result.pass?, 'The sequence should be marked as pass.'
+      assert sequence_result.test_results.all? { |r| r.pass? || r.skip? }, 'All tests should pass'
     end
-    sequence_result = @sequence.start
-    assert sequence_result.pass?, 'The sequence should be marked as pass.'
-    assert sequence_result.test_results.all? { |r| r.pass? || r.skip? }, 'All tests should pass'
   end
 
   def test_evaluate_measure_fail_mismatched_population_counts

--- a/test/sequence/quality_reporting/measure_evaluation_test.rb
+++ b/test/sequence/quality_reporting/measure_evaluation_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require File.expand_path '../../test_helper.rb', __dir__
+
+class MeasureEvaluationSequenceTest < MiniTest::Test
+  def setup
+    @instance = Inferno::Models::TestingInstance.new(url: 'http://www.example.com', selected_module: 'quality_reporting')
+    @instance.save! # this is for convenience.  we could rewrite to ensure nothing gets saved within tests.
+    @instance.measure_to_test = 'TestMeasure'
+    client = FHIR::Client.new(@instance.url)
+    client.use_stu3
+    client.default_json
+    @sequence = Inferno::Sequence::MeasureEvaluationSequence.new(@instance, client, true)
+  end
+
+  MEASURES_TO_TEST = [
+    {   measure_id: 'MitreTestScript-measure-col',
+        example_measurereport: :col_measure_report }
+  ].freeze
+
+  def test_all_pass
+    WebMock.reset!
+
+    MEASURES_TO_TEST.each do |req|
+      measure_report = load_json_fixture(req[:example_measurereport])
+
+      # Mock a request for $evaluate-measure
+      stub_request(:get, /\$evaluate-measure/)
+        .to_return(status: 200, body: measure_report.to_json, headers: {})
+    end
+  end
+
+  def test_evaluate_measure_fail_mismatched_population_counts
+    WebMock.reset!
+
+    @instance.measure_to_test = 'MitreTestScript-measure-col'
+    # These reports do not have matching population counts which should cause the sequence to fail
+    mismatched_measure_report = load_json_fixture(:col_measure_report)
+    all_zeros_report = load_json_fixture(:col_measure_report_all_zero)
+
+    # Stub out the response from the SUT
+    stub_request(:get, %r{www.example.com/Measure})
+      .to_return(status: 200, body: mismatched_measure_report.to_json, headers: {})
+    # Stub out the response from CQF-Ruler which the sequence uses to retrieve "known-good" results
+    stub_request(:get, %r{cqf-ruler-dstu3/fhir})
+      .to_return(status: 200, body: all_zeros_report.to_json, headers: {})
+
+    sequence_result = @sequence.start
+    assert(sequence_result.fail?, 'The sequence should be marked as fail.')
+  end
+
+  def test_evaluate_measure_unsupported_measure_fail
+    WebMock.reset!
+
+    @instance.measure_to_test = 'measure-not-supported'
+    stub_request(:get, /\$evaluate-measure/)
+      .to_return(status: 200)
+
+    sequence_result = @sequence.start
+    assert(sequence_result.fail?, 'The sequence should be marked as fail.')
+  end
+end


### PR DESCRIPTION
# Summary
Add measure evaluation sequence that requires the user select measure they would like to evaulate
## New behavior
New measure evaluation sequence
## Code changes
Added sequence and test for sequence
# Testing guidance
# Testing guidance

  - The "embedded" CQF Ruler instance needs to be running. (`docker-compose up cqf_ruler`) in the docker-deqm-test-client repo. Wait till cqf-ruler is fully up and running before running sequences against it.
  - You can use any system you like as the SUT, but the CQF ruler instance works fine as the SUT and the source of known good (results should always be the same)
- Start the deqm test client and run the measure evaluation sequence
https://jira.mitre.org/browse/TACOSTRAT-356