### PR TITLE
Monkey-patch a configurable timeout into rest-client. 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -79,3 +79,7 @@ presets:
 
 # cqf-ruler data store endpoint
 cqf_ruler_endpoint: http://localhost:8080/cqf-ruler-r4/fhir/
+
+# Timeout for requests to FHIR servers (in seconds)
+# Monkey-patched into rest-client in lib/ext/request.rb
+timeout: 900

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -25,6 +25,7 @@ require_relative 'app/models/module'
 require_relative 'version'
 require_relative 'app/models'
 require_relative 'app/utils/terminology'
+require_relative 'ext/request'
 
 module Inferno
   class App

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -20,6 +20,7 @@ module Inferno
       Inferno::EXTRAS = settings.include_extras
       Inferno::NDJSON_SERVICE_TYPE = settings.ndjson_service_type.to_sym
       Inferno::CQF_RULER = settings.cqf_ruler_endpoint
+      Inferno::TIMEOUT = settings.timeout
 
       if settings.logging_enabled
         $stdout.sync = true # output in Docker is heavily delayed without this

--- a/lib/ext/request.rb
+++ b/lib/ext/request.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Through the use of `prepend` below, this module gets included in RestClient::Request
+# And can call the original `initialize` method as `super`
+# Yes, this is monkey patching, but it's the cleanest way I could find to do this monkey patch
+module RequestExtensions
+  def initialize(args)
+    args[:timeout] = Inferno::TIMEOUT unless args.include?(:timeout)
+    super(args)
+  end
+end
+
+module RestClient
+  class Request
+    prepend RequestExtensions
+  end
+end


### PR DESCRIPTION
# Summary
This PR adds a configurable timeout into `rest-client` (which FHIR::Client uses to make the underlying HTTP requests). Since there's no good way to set a global HTTP timeout for any of: FHIR::Client, rest-client, or Net::HTTP (which rest-client uses under _its_ hood), we end up monkey-patching a longer default timeout into `rest-client`'s `Request#initialize` method (before, it was 60 seconds).
## New behavior
By default, the timeout is set to 900 seconds (15 minutes), but can be changed in `config.yml`.
## Code changes
* Timeout variable set in `config.yml`
* monkey-patch added in `lib/ext/request.rb`
* `Inferno::TIMEOUT global added in `lib/app/endpoint.rb`
# Testing guidance
Run a cqf-ruler instance with >20 EXM_104_R4 patients in it (as well as the requisite measure artifacts); the easiest way to get this is to run `make MEASURE_DIR=EXM_104 PATIENT_COUNT=30` in `fhir-patient-generator`. 

Then run this branch of `deqm-test-client`, point it at `http://localhost:8080/cqf-ruler-r4/fhir`, and select the Quality Reporting sequence. On the first page, pick EXM104 and run through all the relevant tests. 

It's expected (at the moment) that the submit-data test will fail for EXM104, but the `$evaluate-measure` one should pass, after taking more than 60 seconds.
