### PR TITLE
Data requirements

### DIFF
--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -13,6 +13,15 @@ module Inferno
       @client.get "Measure/#{measure_id}/$evaluate-measure#{params_string}", @client.fhir_headers(format: FHIR::Formats::ResourceFormat::RESOURCE_JSON)
     end
 
+    # Run the $data-requirements operation for the given Measure
+    #
+    # measure_id - ID of the Measure to get data requirements for
+    # params - hash of params to form a query in the GET request url
+    def data_requirements(measure_id, params = {})
+      params_string = params.empty? ? '' : "?#{params.to_query}"
+      @client.get "Measure/#{measure_id}/$data-requirements#{params_string}", @client.fhir_headers(format: FHIR::Formats::ResourceFormat::RESOURCE_JSON)
+    end
+
     def create_measure_report(measure_id, patient_id, period_start, period_end)
       FHIR::MeasureReport.new.from_hash(
         type: 'data-collection',
@@ -56,11 +65,6 @@ module Inferno
     def collect_data(measure_id, params = {})
       params_string = params.empty? ? '' : "?#{params.to_query}"
       @client.get "Measure/#{measure_id}/$collect-data#{params_string}", @client.fhir_headers(format: FHIR::Formats::ResourceFormat::RESOURCE_JSON)
-    end
-
-    def data_requirements
-      # TODO
-      nil
     end
 
     def get_measure_resources_by_name(measure_name)
@@ -113,6 +117,15 @@ module Inferno
       raise StandardError, "Could not retrieve measure_evaluation #{measure_id} from CQF Ruler." if evaluation_response.code != 200
 
       FHIR::MeasureReport.new JSON.parse(evaluation_response.body)
+    end
+
+    def get_data_requirements(measure_id, params = {})
+      endpoint = Inferno::CQF_RULER + 'Measure'
+      params_string = params.empty? ? '' : "?#{params.to_query}"
+      data_requirements_response = cqf_ruler_client.client.get("#{measure_evaluation_endpoint}/#{measure_id}/$data-requirements#{params_string}")
+      raise StandardError, "Could not retrieve data_requirements for measure #{measure_id} from CQF Ruler." if data_requirements_response.code != 200
+
+      FHIR::Library.new JSON.parse(data_requirements_response.body)
     end
 
     def get_library_resource(library_id)

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -122,7 +122,7 @@ module Inferno
     def get_data_requirements(measure_id, params = {})
       endpoint = Inferno::CQF_RULER + 'Measure'
       params_string = params.empty? ? '' : "?#{params.to_query}"
-      data_requirements_response = cqf_ruler_client.client.get("#{measure_evaluation_endpoint}/#{measure_id}/$data-requirements#{params_string}")
+      data_requirements_response = cqf_ruler_client.client.get("#{endpoint}/#{measure_id}/$data-requirements#{params_string}")
       raise StandardError, "Could not retrieve data_requirements for measure #{measure_id} from CQF Ruler." if data_requirements_response.code != 200
 
       FHIR::Library.new JSON.parse(data_requirements_response.body)

--- a/lib/modules/quality_reporting/data_requirements_sequence.rb
+++ b/lib/modules/quality_reporting/data_requirements_sequence.rb
@@ -26,7 +26,8 @@ module Inferno
         end
 
         assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running this sequence.')
-        
+        measure_id = @instance.measure_to_test
+
         # Get data requirements from cqf-ruler
         expected_results_library = get_data_requirements(measure_id, PARAMS.compact)
         expectedDR = expected_results_library.dataRequirement

--- a/lib/modules/quality_reporting/data_requirements_sequence.rb
+++ b/lib/modules/quality_reporting/data_requirements_sequence.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative '../../app/utils/measure_operations'
+
+module Inferno
+  module Sequence
+    class DataRequirementsSequence < SequenceBase
+      include MeasureOperations
+      title 'Data Requirements'
+
+      test_id_prefix 'data_requirements'
+
+      description 'Ensure that data requirements and parameters relevant to a measure can be requested via the $data-requirements operation'
+
+      # Parameters appended to the url for $data-requirements call
+      PARAMS = {
+        'periodStart': '2019-01-01',
+        'periodEnd': '2019-12-31'
+      }.freeze
+
+      test 'Data Requirements valid response' do
+        metadata do
+          id '01'
+          link 'https://www.hl7.org/fhir/measure-operation-data-requirements.html'
+          description 'Request data requirements relevant to a measure, and then verify module definition results.'
+        end
+
+        assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running this sequence.')
+        
+        # Get data requirements from cqf-ruler
+        expected_results_library = get_data_requirements(measure_id, PARAMS.compact)
+        expectedDR = expected_results_library.dataRequirement
+
+        # Get data requirements from client
+        data_requirements_response = data_requirements(measure_id, PARAMS.compact)
+        assert_response_ok data_requirements_response
+
+        # Load response body into a FHIR Library class, expected to contain dataRequirement array
+        data_library = FHIR.from_contents(data_requirements_response.body)
+        actualDR = data_library&.dataRequirement
+        assert(!actualDR.nil?, "Client provided no data requirements for measure #{measure_id}")
+
+        # Compare data requirements to expected
+        assert((expectedDR-actualDR).blank?, "Client data-requirements is missing expected data requirements for measure #{measure_id}")
+        assert((actualDR-expectedDR).blank?, "Client data-requirements contains unexpected data requirements for measure #{measure_id}")
+
+      end
+    end
+  end
+end

--- a/lib/modules/quality_reporting/measure_availability_sequence.rb
+++ b/lib/modules/quality_reporting/measure_availability_sequence.rb
@@ -32,7 +32,7 @@ module Inferno
         measure_identifier = measure_resource.resource.identifier.find { |id| id.system == 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms' }
         measure_version = measure_resource.resource.version
         query_response = @client.search(FHIR::Measure, search: { parameters: { identifier: measure_identifier.value, version: measure_version } })
-        assert_equal query_response.resource.total, 1, "Expected to find measure with id #{measure_id}"
+        assert_equal 1, query_response.resource.total, "Expected to find measure with id #{measure_id}"
 
         # Update instance variable to be the ID we get back from the SUT
         @instance.measure_to_test = query_response.resource.entry.first.resource.id

--- a/lib/modules/quality_reporting_module.yml
+++ b/lib/modules/quality_reporting_module.yml
@@ -18,6 +18,7 @@ test_sets:
           - ResourceSequence
           - SubmitDataSequence
           - MeasureEvaluationSequence
+          - DataRequirementsSequence
       #- name: CMS165 Bulk Data Reporting
         #sequences:
           #- CMS165BulkDataReportingSequence


### PR DESCRIPTION
# Summary
Adds Data Requirements sequence for testing

## New behavior
Data requirements sequence is now available as part of the FHIR Quality Reporting Module and compares cqf-ruler returned dataRequirements to client returned dataRequirements. Does not include checks against repeated requirements.

## Code changes
Add data requirements sequence, similar to measure evaluation sequence. Also adds data requirements cqf-ruler and client calls in the measure_operations.rb file

# Testing guidance
My testing involved using the preloaded cqf-ruler docker image via running `docker run -p 8080:8080 tacoma/cqf-ruler-preloaded:0.3.0.no-vs` and using the same docker image as the fhir client under test (input through the local UI created with deqm-test-client `bundle exec rackup`). Obviously, both returned the same data-requirements, so this shows basic functionality, but there may be a more compelling test with a different fhir client if the test knows of one that implements data requirements with the same measures as cqf-ruler.
Tests should return a pass against a working fhir client that supports data-requirements:
<img width="961" alt="Screen Shot 2021-01-05 at 3 07 45 PM" src="https://user-images.githubusercontent.com/2643955/103695431-8ca9d480-4f6a-11eb-820f-d649175ee02b.png">
