### PR TITLE
Add helper for assembling search queries from data requirements

### DIFF
--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -162,23 +162,20 @@ module Inferno
 
     def get_data_requirements_queries(data_requirement)
       # hashes with { endpoint => FHIR Type, params => { queries } }
-      ret_val = []
-      dr_with_filters = data_requirement.select { |dr| !dr.codeFilter.nil? && !dr.codeFilter.first.nil? }
+      data_requirement
+        .select { |dr| !dr.codeFilter.nil? && !dr.codeFilter.first.nil? }
+        .map do |dr|
+          q = { 'endpoint' => dr.type, 'params' => {} }
 
-      dr_with_filters.each do |dr|
-        q = { 'endpoint' => dr.type, 'params' => {} }
+          # prefer specific code filter first before valueSet
+          if !dr.codeFilter.first.code&.first.nil?
+            q['params'][dr.codeFilter.first.path.to_s] = dr.codeFilter.first.code.first.code
+          elsif !dr.codeFilter.first.valueSet.nil?
+            q['params']["#{dr.codeFilter.first.path}:in"] = dr.codeFilter.first.valueSet
+          end
 
-        # prefer specific code filter first before valueSet
-        if !dr.codeFilter.first.code&.first.nil?
-          q['params'][dr.codeFilter.first.path.to_s] = dr.codeFilter.first.code.first.code
-        elsif !dr.codeFilter.first.valueSet.nil?
-          q['params']["#{dr.codeFilter.first.path}:in"] = dr.codeFilter.first.valueSet
+          q
         end
-
-        ret_val.push(q)
-      end
-
-      ret_val
     end
   end
 end

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -159,5 +159,26 @@ module Inferno
         .uniq
         .to_a
     end
+
+    def get_data_requirements_queries(data_requirement)
+      # hashes with { endpoint => FHIR Type, params => { queries } }
+      ret_val = []
+      dr_with_filters = data_requirement.select { |dr| !dr.codeFilter.nil? && !dr.codeFilter.first.nil? }
+
+      dr_with_filters.each do |dr|
+        q = { 'endpoint' => dr.type, 'params' => {} }
+
+        # prefer specific code filter first before valueSet
+        if !dr.codeFilter.first.code&.first.nil?
+          q['params'][dr.codeFilter.first.path.to_s] = dr.codeFilter.first.code.first.code
+        elsif !dr.codeFilter.first.valueSet.nil?
+          q['params']["#{dr.codeFilter.first.path}:in"] = dr.codeFilter.first.valueSet
+        end
+
+        ret_val.push(q)
+      end
+
+      ret_val
+    end
   end
 end

--- a/test/unit/measure_operations_test.rb
+++ b/test/unit/measure_operations_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require File.expand_path '../test_helper.rb', __dir__
+require_relative '../../lib/app/utils/measure_operations'
+
+class MeasureOperationsTest < MiniTest::Test
+  include Inferno::MeasureOperations
+
+  DATA_REQS = [
+    {
+      'type' => 'Procedure',
+      'codeFilter' => [
+        {
+          'path' => 'code',
+          'valueSet' => 'http://example.com/vs-1'
+        }
+      ]
+    },
+    {
+      'type' => 'Encounter',
+      'codeFilter' => [
+        {
+          'path' => 'type',
+          'valueSet' => 'http://example.com/vs-2'
+        }
+      ]
+    },
+    {
+      'type' => 'Condition',
+      'codeFilter' => [
+        {
+          'path' => 'code',
+          'code' => [
+            {
+              'code' => 'example-code',
+              'system' => 'http://example.com/example-system'
+            }
+          ]
+        }
+      ]
+    }
+  ].map { |dr| FHIR::DataRequirement.new(dr) }
+
+  EXPECTED_QUERIES = [
+    {
+      'endpoint' => 'Procedure',
+      'params' => {
+        'code:in' => 'http://example.com/vs-1'
+      }
+    },
+    {
+      'endpoint' => 'Encounter',
+      'params' => {
+        'type:in' => 'http://example.com/vs-2'
+      }
+    },
+    {
+      'endpoint' => 'Condition',
+      'params' => {
+        'code' => 'example-code'
+      }
+    }
+  ].freeze
+
+  def test_data_requirements_queries
+    dr = get_data_requirements_queries(DATA_REQS)
+    assert_equal dr, EXPECTED_QUERIES
+  end
+end


### PR DESCRIPTION
# Summary

New unit-tested function for assembling a hash of FHIR queries to make to gather the required resources specified in the FHIR data requirements for a given measure. Resulting object is as follows:

``` ruby
[
    {
      'endpoint' => 'The FHIR Data Type',
      'params' => {
        'query parameter' => 'value to search for'
      }
    },
...
]
```

## New behavior

N/A for now. To be linked in with data requirements sequence later per #25 

## Code changes

* New function in measure_operations
* Unit tests

# Testing guidance

* `bundle exec rake test TEST=./test/unit/measure_operations_test.rb`
* Certify that output of function coincides with input of initial functionality in #25 