### PR TITLE
single resource test

### DIFF
--- a/lib/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/modules/quality_reporting/submit_data_sequence.rb
@@ -57,7 +57,7 @@ module Inferno
         metadata do
           id '02'
           link 'https://www.hl7.org/fhir/measure-operation-submit-data.html'
-          description 'Submit resources relevant to a measure, and then verify they persist on the server.'
+          description 'Submit a single resource relevant to a measure, and then verify it persisted on the server.'
         end
 
         assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running Reporting Actions sequences.')

--- a/lib/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/modules/quality_reporting/submit_data_sequence.rb
@@ -52,6 +52,41 @@ module Inferno
           assert(search_bundle.total.positive?, "Search for a #{r.resourceType} with identifier #{identifier} returned no results")
         end
       end
+
+      test 'Submit Data single resource submission' do
+        metadata do
+          id '02'
+          link 'https://www.hl7.org/fhir/measure-operation-submit-data.html'
+          description 'Submit resources relevant to a measure, and then verify they persist on the server.'
+        end
+
+        assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running Reporting Actions sequences.')
+
+        @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
+
+        resources = [get_data_requirements_resources(@instance.data_requirements_queries).sample]
+        measure_report = create_measure_report(@instance.measure_to_test, '2019', '2019')
+
+        # Submit the data
+        submit_data_response = submit_data(@instance.measure_to_test, resources, measure_report)
+        assert_response_ok(submit_data_response)
+
+        resources.push(measure_report)
+
+        # GET and assert presence of all submitted resources
+        resources.each do |r|
+          identifier = r.identifier&.first&.value
+          assert !identifier.nil?
+
+          # Search for resource by identifier
+          search_response = @client.search(r.class, search: { parameters: { identifier: identifier } })
+          assert_response_ok search_response
+          search_bundle = search_response.resource
+
+          # Expect a non-empty searchset Bundle
+          assert(search_bundle.total.positive?, "Search for a #{r.resourceType} with identifier #{identifier} returned no results")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary
Adds a test to the submit data sequence to submit a single resource.

## New behavior
Second submit data test runs, very similar to first test, but randomly chooses a single resource to submit from the resource list.

## Code changes
Adds test to submit_data_sequence.rb

# Testing guidance
Testing involved using the preloaded cqf-ruler docker image via running `docker run -p 8080:8080 tacoma/cqf-ruler-preloaded:0.3.0.no-vs` and using the same docker image as the fhir client under test (input through the local UI created with deqm-test-client `bundle exec rackup`). Tests should return a pass for all submit data tests.
