### PR TITLE
Code from Connectathon

### DIFF
--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -207,6 +207,13 @@ module Inferno
         .to_a
     end
 
+    def update_code_systems
+      # Expand valuesets into codesystem resources to support code:in queries
+      response = cqf_ruler_client.client.get(Inferno::CQF_RULER + '/$updateCodeSystems')
+      binding.pry
+      raise StandardError, 'Error updating codesystems' if response.code != 200
+    end
+
     def get_data_requirements_queries(data_requirement)
       # hashes with { endpoint => FHIR Type, params => { queries } }
       queries = data_requirement

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -210,7 +210,6 @@ module Inferno
     def update_code_systems
       # Expand valuesets into codesystem resources to support code:in queries
       response = cqf_ruler_client.client.get(Inferno::CQF_RULER + '/$updateCodeSystems')
-      binding.pry
       raise StandardError, 'Error updating codesystems' if response.code != 200
     end
 

--- a/lib/app/utils/measure_operations.rb
+++ b/lib/app/utils/measure_operations.rb
@@ -19,7 +19,6 @@ module Inferno
     # params - hash of params to form a query in the GET request url
     def data_requirements(measure_id, params = {})
       params_string = params.empty? ? '' : "?#{params.to_query}"
-
       @client.get "Measure/#{measure_id}/$data-requirements#{params_string}", @client.fhir_headers(format: FHIR::Formats::ResourceFormat::RESOURCE_JSON)
     end
 
@@ -226,9 +225,6 @@ module Inferno
           elsif dr.codeFilter&.first&.valueSet
             q['params']["#{dr.codeFilter.first.path}:in"] = dr.codeFilter.first.valueSet
           end
-
-          # TODO: why is dr for 104 Medication and not MedicationRequest on cqf-ruler
-          q['endpoint'] = 'MedicationRequest' if q['endpoint'] == 'Medication'
 
           q
         end

--- a/lib/app/views/prerequisite_field_dropdown.erb
+++ b/lib/app/views/prerequisite_field_dropdown.erb
@@ -18,8 +18,8 @@
     <div class="form-group">
         <select class="custom-select custom-select-lg" name="<%=prerequisite.to_s%>" style="margin-left: 10px;" id="<%=prerequisite.to_s%>"">
         <% instance.module.testable_measures.each do |measure| %>
-            <% if id = measure.resource.identifier.find { |id| id.system == 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms' } %>
-              <option value=<%=measure.resource.id%>> <%= "CMS#{id.value} v#{measure.resource.version}" %> </option>
+            <% if identifier = measure.resource.identifier.find { |identifier| identifier.system == 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms' } %>
+              <option value=<%="#{identifier.value}|#{measure.resource.version}"%>> <%= "CMS#{identifier.value} v#{measure.resource.version}" %> </option>
             <% end %>
         <% end %>
         <input type="hidden" name="prerequisite_input" id="prerequisite_input" value=<%=value%> />

--- a/lib/modules/quality_reporting/data_requirements_sequence.rb
+++ b/lib/modules/quality_reporting/data_requirements_sequence.rb
@@ -26,24 +26,27 @@ module Inferno
         end
 
         assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running this sequence.')
-        measure_id = @instance.measure_to_test
+
+        measure_identifier, measure_version = @instance.measure_to_test.split('|')
+        measure_resource_embedded = get_measure_from_embedded_server(measure_identifier, measure_version)
+        measure_resource_system = get_measure_from_test_server(measure_identifier, measure_version)
 
         # Get data requirements from cqf-ruler
-        expected_results_library = get_data_requirements(measure_id, PARAMS.compact)
+        expected_results_library = get_data_requirements(measure_resource_embedded.id, PARAMS.compact)
         expected_dr = expected_results_library.dataRequirement
 
         # Get data requirements from client
-        data_requirements_response = data_requirements(measure_id, PARAMS.compact)
+        data_requirements_response = data_requirements(measure_resource_system.id, PARAMS.compact)
         assert_response_ok data_requirements_response
 
         # Load response body into a FHIR Library class, expected to contain dataRequirement array
         data_library = FHIR.from_contents(data_requirements_response.body)
         actual_dr = data_library&.dataRequirement
-        assert(!actual_dr.nil?, "Client provided no data requirements for measure #{measure_id}")
+        assert(!actual_dr.nil?, "Client provided no data requirements for measure #{@instance.measure_to_test}")
 
         # Compare data requirements to expected
-        assert((expected_dr - actual_dr).blank?, "Client data-requirements is missing expected data requirements for measure #{measure_id}")
-        assert((actual_dr - expected_dr).blank?, "Client data-requirements contains unexpected data requirements for measure #{measure_id}")
+        assert((expected_dr - actual_dr).blank?, "Client data-requirements is missing expected data requirements for measure #{@instance.measure_to_test}")
+        assert((actual_dr - expected_dr).blank?, "Client data-requirements contains unexpected data requirements for measure #{@instance.measure_to_test}")
 
         # store data requirements queries for future sequence use
         queries = get_data_requirements_queries(actual_dr)

--- a/lib/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/modules/quality_reporting/submit_data_sequence.rb
@@ -25,15 +25,19 @@ module Inferno
 
         assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running Reporting Actions sequences.')
 
+        measure_identifier, measure_version = @instance.measure_to_test.split('|')
+        measure_resource_system = get_measure_from_test_server(measure_identifier, measure_version)
+
         @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
 
         # TODO: How do we decide which patient we are submitting for, if applicable???
 
+        # TODO: If the SUT does not support the $data-requirements operation, we could have a fallback here to get a set list of resources just to test submission
         resources = get_data_requirements_resources(@instance.data_requirements_queries)
-        measure_report = create_measure_report(@instance.measure_to_test, '2019-01-01', '2019-12-31')
+        measure_report = create_measure_report(measure_resource_system.url, '2019-01-01', '2019-12-31')
 
         # Submit the data
-        submit_data_response = submit_data(@instance.measure_to_test, resources, measure_report)
+        submit_data_response = submit_data(measure_resource_system.id, resources, measure_report)
         assert_response_ok(submit_data_response)
 
         resources.push(measure_report)
@@ -62,13 +66,16 @@ module Inferno
 
         assert(!@instance.measure_to_test.nil?, 'No measure selected. You must run the Prerequisite sequences prior to running Reporting Actions sequences.')
 
+        measure_identifier, measure_version = @instance.measure_to_test.split('|')
+        measure_resource_system = get_measure_from_test_server(measure_identifier, measure_version)
+
         @client.additional_headers = { 'x-api-key': @instance.api_key, 'Authorization': @instance.auth_header } if @instance.api_key && @instance.auth_header
 
         resources = [get_data_requirements_resources(@instance.data_requirements_queries).sample]
-        measure_report = create_measure_report(@instance.measure_to_test, '2019', '2019')
+        measure_report = create_measure_report(measure_resource_system.url, '2019-01-01', '2019-12-31')
 
         # Submit the data
-        submit_data_response = submit_data(@instance.measure_to_test, resources, measure_report)
+        submit_data_response = submit_data(measure_resource_system.id, resources, measure_report)
         assert_response_ok(submit_data_response)
 
         resources.push(measure_report)

--- a/lib/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/modules/quality_reporting/submit_data_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
         # TODO: How do we decide which patient we are submitting for, if applicable???
 
         resources = get_data_requirements_resources(@instance.data_requirements_queries)
-        measure_report = create_measure_report(@instance.measure_to_test, '2019', '2019')
+        measure_report = create_measure_report(@instance.measure_to_test, '2019-01-01', '2019-12-31')
 
         # Submit the data
         submit_data_response = submit_data(@instance.measure_to_test, resources, measure_report)

--- a/lib/modules/quality_reporting/submit_data_sequence.rb
+++ b/lib/modules/quality_reporting/submit_data_sequence.rb
@@ -32,7 +32,9 @@ module Inferno
 
         # TODO: How do we decide which patient we are submitting for, if applicable???
 
-        # TODO: If the SUT does not support the $data-requirements operation, we could have a fallback here to get a set list of resources just to test submission
+        # Call the $updateCodeSystems workaround on embedded cqf-ruler so code:in queries work
+        update_code_systems
+
         resources = get_data_requirements_resources(@instance.data_requirements_queries)
         measure_report = create_measure_report(measure_resource_system.url, '2019-01-01', '2019-12-31')
 

--- a/lib/modules/quality_reporting_module.yml
+++ b/lib/modules/quality_reporting_module.yml
@@ -11,7 +11,7 @@ test_sets:
         overview: The server satisfies prerequisite state for quality reporting.
         sequences:
           - MeasureAvailability
-          - ValueSetSequence
+          #- ValueSetSequence
       - name: Reporting Actions
         overview: The server correctly handles reporting actions.
         sequences:

--- a/lib/modules/quality_reporting_module.yml
+++ b/lib/modules/quality_reporting_module.yml
@@ -18,7 +18,7 @@ test_sets:
           - ResourceSequence
           - DataRequirementsSequence
           - SubmitDataSequence
-          - MeasureEvaluationSequence
+          #- MeasureEvaluationSequence
       #- name: CMS165 Bulk Data Reporting
         #sequences:
           #- CMS165BulkDataReportingSequence


### PR DESCRIPTION
# Summary

This code incorporates various bug fixes/flow updates to the $submit-data workflow present in the test client.

## New behavior

Not a ton. Most of this was to support a different system under test other than cqf-ruler, but the green checks should still be the green checks.

The different behavior under the hood is that the passing around of the measure to test is a little different know and the data requirements queries are more fleshed out.

## Code changes

* Fix issue in `create_measure_report` where measure was referenced improperly
* Fix casing of `measurereport` parameter now that that bug was fixed in cqf-ruler
* Included default set of resources to query for in mock EHR if the system under test has not implemented the data requirements operation
* Disabled ValueSet sequence and Measure calculation sequence (only focused on submit data workflow right now)
* Add workaround to call $updateCodeSystems on the embedded cqf-ruler client during submit data 

# Testing guidance

* Spin up cqf-ruler locally and post a connectathon measure bundle to it. This will include the measure/libraries as well as some sample test patient data
* Run through all the tests and inspect the http requests made, you should see a valid submit data payload and the valid GETs to retrieve them
